### PR TITLE
Add kubernetes cluster & namespace name secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,14 @@ The default set of capabilities is usually sufficient for a CI/CD pipeline. Thes
 
 ## GitHub Actions Secrets
 
-If a list of GitHub repositories is supplied via the `github_repositories` variable, [GitHub Actions Secrets] will be created in those repositories, containing the serviceaccount `ca.crt` and `token` values, for use in GitHub Actions CI/CD pipelines.
+If a list of GitHub repositories is supplied via the `github_repositories` variable, the following [GitHub Actions Secrets] will be created in those repositories:
 
-By default, these secrets are named `KUBE_CERT` and `KUBE_TOKEN`. The variables `github_actions_secret_kube_cert` and `github_actions_secret_kube_token` can be supplied to change these names.
+| Default secret name | Description | Terraform variable to change the name |
+|---------------------|-------------|---------------------------------------|
+| `KUBE_CERT` | ServiceAccount `ca.crt` | `github_actions_secret_kube_cert` |
+| `KUBE_TOKEN` | ServiceAccount `token` | `github_actions_secret_kube_token` |
+| `KUBE_CLUSTER` | Cluster name | `github_actions_secret_kube_cluster` |
+| `KUBE_NAMESPACE` | Namespace name | `github_actions_secret_kube_namespace` |
 
 ## Inputs
 
@@ -23,6 +28,8 @@ By default, these secrets are named `KUBE_CERT` and `KUBE_TOKEN`. The variables 
 | github_repositories | GitHub repositories in which to create Github Actions Secrets | list(string) | [] | no |
 | github_actions_secret_kube_cert | The name of the Github Actions Secret containing the `ca.crt` | string | KUBE_CERT | no |
 | github_actions_secret_kube_token | The name of the Github Actions Secret containing the `token` | string | KUBE_TOKEN | no |
+| github_actions_secret_kube_cluster | The name of the Github Actions Secret containing the kubernetes cluster name | string | KUBE_CLUSTER | no |
+| github_actions_secret_kube_namespace | The name of the Github Actions Secret containing the namespace name | string | KUBE_NAMESPACE | no |
 | serviceaccount_rules | The capabilities of the serviceaccount | list(object) | see `variables.tf` | no |
 
 [Github Actions Secrets]: https://docs.github.com/en/actions/reference/encrypted-secrets

--- a/main.tf
+++ b/main.tf
@@ -58,3 +58,17 @@ resource "github_actions_secret" "serviceaccount-token" {
   secret_name     = var.github_actions_secret_kube_token
   plaintext_value = lookup(data.kubernetes_secret.github_actions_secret.data, "token")
 }
+
+resource "github_actions_secret" "cluster-name" {
+  for_each        = toset(var.github_repositories)
+  repository      = each.key
+  secret_name     = var.github_actions_secret_kube_cluster
+  plaintext_value = var.kubernetes_cluster
+}
+
+resource "github_actions_secret" "cluster-namespace" {
+  for_each        = toset(var.github_repositories)
+  repository      = each.key
+  secret_name     = var.github_actions_secret_kube_namespace
+  plaintext_value = var.namespace
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,8 @@
+variable "kubernetes_cluster" {
+  description = "The name of the kubernetes cluster, for app. deployment"
+  default = "live-1.cloud-platform.service.justice.gov.uk"
+}
+
 variable "namespace" {
   description = "The namespace in which this serviceaccount will be created"
 }
@@ -71,6 +76,16 @@ variable "github_repositories" {
   description = "GitHub repositories in which to create github actions secrets"
   type        = list(string)
   default     = []
+}
+
+variable "github_actions_secret_kube_cluster" {
+  description = "The name of the github actions secret containing the kubernetes cluster name"
+  default     = "KUBE_CLUSTER"
+}
+
+variable "github_actions_secret_kube_namespace" {
+  description = "The name of the github actions secret containing the kubernetes namespace name"
+  default     = "KUBE_NAMESPACE"
 }
 
 variable "github_actions_secret_kube_cert" {


### PR DESCRIPTION
This changes the module so that it also writes
github actions secrets containing the cluster name
and the target namespace name.

This should mean that most teams do not need to
hard-code any cloud platform-specific values in
their github actions deployment pipelines.

> Please create the 0.2 release of this module, after merging this PR
