### PR TITLE
Increase scope of default serviceaccount permissions

### DIFF
--- a/examples/serviceaccount.tf
+++ b/examples/serviceaccount.tf
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.4"
 
   namespace           = var.namespace
   github_repositories = ["my-repo"]

--- a/template/serviceaccount.tmpl
+++ b/template/serviceaccount.tmpl
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.4"
 
   namespace = var.namespace
 

--- a/variables.tf
+++ b/variables.tf
@@ -36,6 +36,7 @@ variable "serviceaccount_rules" {
         "patch",
         "get",
         "create",
+        "update",
         "delete",
         "list",
         "watch",

--- a/variables.tf
+++ b/variables.tf
@@ -45,11 +45,14 @@ variable "serviceaccount_rules" {
       api_groups = [
         "extensions",
         "apps",
+        "batch",
         "networking.k8s.io",
       ]
       resources = [
         "deployments",
         "ingresses",
+        "cronjobs",
+        "jobs",
       ]
       verbs = [
         "get",


### PR DESCRIPTION
This change adds to the default serviceaccount permissions, enabling management of:

* secrets
* jobs
* cronjobs

While putting together a tutorial on using Helm via GitHub Actions to continuously deploy the multicontainer demo app, I noticed that the default serviceaccount permissions had to be modified to make it work.

I think the majority of services we host on the Cloud Platform will have some or all of these resources, so it makes sense if our default serviceaccount permissions work "out of the box".

> Please create a 0.4 release of the module, after merging this PR.

- Add permissions on batch/(cron)jobs
- Update the module version in the examples to 0.4
- Allow serviceaccount to "update" secrets
