### PR TITLE
Remove default value for kubernetes_cluster variable, update example and template

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -1,0 +1,19 @@
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}
+
+provider "github" {
+  token = var.github_token
+  owner = var.github_owner
+}

--- a/examples/serviceaccount.tf
+++ b/examples/serviceaccount.tf
@@ -1,6 +1,6 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.5"
+  source = "../"
 
-  namespace           = var.namespace
+  namespace           = "my-namespace"
   github_repositories = ["my-repo"]
 }

--- a/examples/serviceaccount.tf
+++ b/examples/serviceaccount.tf
@@ -1,3 +1,9 @@
+/*
+ * When using this module through the cloud-platform-environments,
+ * this variable is automatically supplied by the pipeline TF_VAR_kubernetes_cluster.
+ *
+*/
+variable "kubernetes_cluster" {}
 module "serviceaccount" {
   source = "../"
 

--- a/examples/versions.tf
+++ b/examples/versions.tf
@@ -1,3 +1,14 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.14"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    github = {
+      source = "integrations/github"
+    }
+  }
 }

--- a/template/serviceaccount.tmpl
+++ b/template/serviceaccount.tmpl
@@ -2,6 +2,7 @@ module "serviceaccount" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.5"
 
   namespace = var.namespace
+  kubernetes_cluster = var.kubernetes_cluster
 
   # Uncomment and provide repository names to create github actions secrets
   # containing the ca.crt and token for use in github actions CI/CD pipelines

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,5 @@
 variable "kubernetes_cluster" {
   description = "The name of the kubernetes cluster, for app. deployment"
-  default = "live-1.cloud-platform.service.justice.gov.uk"
 }
 
 variable "namespace" {


### PR DESCRIPTION
- Add main.tf
- update serviceaccount for namespace value and versions.yf to include github provider block in example
- Remove default value of kubernetes_cluster variable. This is passed from pipeline as TF_VAR_kubernetes_cluster
- Update template for the variable change