### PR TITLE
Update service account rules

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -29,6 +29,7 @@ variable "serviceaccount_rules" {
         "deployment",
         "secrets",
         "services",
+        "configmaps",
         "pods",
       ]
       verbs = [


### PR DESCRIPTION
Added configmaps to default service account rules.

As noticed users need "configmaps" rule in their pipeline.