### PR TITLE
Bump template version to 0.7.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,28 +10,34 @@ The default set of capabilities is usually sufficient for a CI/CD pipeline. Thes
 
 If a list of GitHub repositories is supplied via the `github_repositories` variable, the following [GitHub Actions Secrets] will be created in those repositories:
 
-| Default secret name | Description | Terraform variable to change the name |
-|---------------------|-------------|---------------------------------------|
-| `KUBE_CERT` | ServiceAccount `ca.crt` | `github_actions_secret_kube_cert` |
-| `KUBE_TOKEN` | ServiceAccount `token` | `github_actions_secret_kube_token` |
-| `KUBE_CLUSTER` | Cluster name | `github_actions_secret_kube_cluster` |
-| `KUBE_NAMESPACE` | Namespace name | `github_actions_secret_kube_namespace` |
+| Default secret name | Description             | Terraform variable to change the name  |
+| ------------------- | ----------------------- | -------------------------------------- |
+| `KUBE_CERT`         | ServiceAccount `ca.crt` | `github_actions_secret_kube_cert`      |
+| `KUBE_TOKEN`        | ServiceAccount `token`  | `github_actions_secret_kube_token`     |
+| `KUBE_CLUSTER`      | Cluster name            | `github_actions_secret_kube_cluster`   |
+| `KUBE_NAMESPACE`    | Namespace name          | `github_actions_secret_kube_namespace` |
 
-*Note* The terraform Github provider does not seem to trigger on changes in the parameters, but deleting the `serviceaccount` in the namespace will make it update the repo secrets too.
+_Note_ The terraform Github provider does not seem to trigger on changes in the parameters, but deleting the `serviceaccount` in the namespace will make it update the repo secrets too.
 
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| namespace | The namespace in which to create the serviceaccount | string | | yes |
-| serviceaccount_name | The name of the serviceaccount | string | cd-serviceaccount | no |
-| role_name | The name of the created role | string | serviceaccount-role | no |
-| rolebinding_name | The name of the created rolebinding | string | serviceaccount-rolebinding | no |
-| github_repositories | GitHub repositories in which to create Github Actions Secrets | list(string) | [] | no |
-| github_actions_secret_kube_cert | The name of the Github Actions Secret containing the `ca.crt` | string | KUBE_CERT | no |
-| github_actions_secret_kube_token | The name of the Github Actions Secret containing the `token` | string | KUBE_TOKEN | no |
-| github_actions_secret_kube_cluster | The name of the Github Actions Secret containing the kubernetes cluster name | string | KUBE_CLUSTER | no |
-| github_actions_secret_kube_namespace | The name of the Github Actions Secret containing the namespace name | string | KUBE_NAMESPACE | no |
-| serviceaccount_rules | The capabilities of the serviceaccount | list(object) | see `variables.tf` | no |
+| Name                                 | Description                                                                  |     Type     |          Default           | Required |
+| ------------------------------------ | ---------------------------------------------------------------------------- | :----------: | :------------------------: | :------: |
+| namespace                            | The namespace in which to create the serviceaccount                          |    string    |                            |   yes    |
+| serviceaccount_name                  | The name of the serviceaccount                                               |    string    |     cd-serviceaccount      |    no    |
+| role_name                            | The name of the created role                                                 |    string    |    serviceaccount-role     |    no    |
+| rolebinding_name                     | The name of the created rolebinding                                          |    string    | serviceaccount-rolebinding |    no    |
+| github_repositories                  | GitHub repositories in which to create Github Actions Secrets                | list(string) |             []             |    no    |
+| github_actions_secret_kube_cert      | The name of the Github Actions Secret containing the `ca.crt`                |    string    |         KUBE_CERT          |    no    |
+| github_actions_secret_kube_token     | The name of the Github Actions Secret containing the `token`                 |    string    |         KUBE_TOKEN         |    no    |
+| github_actions_secret_kube_cluster   | The name of the Github Actions Secret containing the kubernetes cluster name |    string    |        KUBE_CLUSTER        |    no    |
+| github_actions_secret_kube_namespace | The name of the Github Actions Secret containing the namespace name          |    string    |       KUBE_NAMESPACE       |    no    |
+| serviceaccount_rules                 | The capabilities of the serviceaccount                                       | list(object) |     see `variables.tf`     |    no    |
 
-[Github Actions Secrets]: https://docs.github.com/en/actions/reference/encrypted-secrets
+[github actions secrets]: https://docs.github.com/en/actions/reference/encrypted-secrets
+
+## Release
+
+When making changes to this Terraform module you'll need to update the template file as it points to a specific version.
+
+Update: `./template/serviceaccount.tmpl`

--- a/template/serviceaccount.tmpl
+++ b/template/serviceaccount.tmpl
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.7.4"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster


### PR DESCRIPTION
When creating a serviceaccount using the CLI it calls the template file in this repository. If this hasn't been updated post release, the user will pull an older (possibly broken release). This change adds the relevant update and includes a small line in the README about how to do it in the future.

Additional change: Format the README using linting tool.