### PR TITLE
Add prefix var for gh secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_env_prefix"></a> [env\_prefix](#input\_env\_prefix) | the prefix for github actions secret name eg. DEV or PROD | `string` | `""` | no |
 | <a name="input_github_actions_secret_kube_cert"></a> [github\_actions\_secret\_kube\_cert](#input\_github\_actions\_secret\_kube\_cert) | The name of the github actions secret containing the serviceaccount ca.crt | `string` | `"KUBE_CERT"` | no |
 | <a name="input_github_actions_secret_kube_cluster"></a> [github\_actions\_secret\_kube\_cluster](#input\_github\_actions\_secret\_kube\_cluster) | The name of the github actions secret containing the kubernetes cluster name | `string` | `"KUBE_CLUSTER"` | no |
 | <a name="input_github_actions_secret_kube_namespace"></a> [github\_actions\_secret\_kube\_namespace](#input\_github\_actions\_secret\_kube\_namespace) | The name of the github actions secret containing the kubernetes namespace name | `string` | `"KUBE_NAMESPACE"` | no |

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The default set of capabilities is usually sufficient for a CI/CD pipeline. Thes
 
 ## GitHub Actions Secrets
 
-If a list of GitHub repositories is supplied via the `github_repositories` variable, the following [GitHub Actions Secrets] will be created in those repositories:
+If a list of GitHub repositories is supplied via the `github_repositories` variable, the [GitHub Actions Secrets] below will be created in those repositories. If you need to specify a prefix for those variables (useful for multi-cluster applications), you can do so with the `env_prefix` variable:
 
 | Default secret name | Description             | Terraform variable to change the name  |
 | ------------------- | ----------------------- | -------------------------------------- |

--- a/main.tf
+++ b/main.tf
@@ -70,28 +70,28 @@ resource "kubernetes_role_binding" "github-actions-rolebinding" {
 resource "github_actions_secret" "serviceaccount-cert" {
   for_each        = toset(var.github_repositories)
   repository      = each.key
-  secret_name     = var.github_actions_secret_kube_cert
+  secret_name     = var.env_prefix != "" ? "${var.env_prefix}_${var.github_actions_secret_kube_cert}" : var.github_actions_secret_kube_cert
   plaintext_value = lookup(data.kubernetes_secret.github_actions_secret.data, "ca.crt")
 }
 
 resource "github_actions_secret" "serviceaccount-token" {
   for_each        = toset(var.github_repositories)
   repository      = each.key
-  secret_name     = var.github_actions_secret_kube_token
+  secret_name     = var.env_prefix  != ""? "${var.env_prefix}_${var.github_actions_secret_kube_token}" : var.github_actions_secret_kube_token
   plaintext_value = lookup(data.kubernetes_secret.github_actions_secret.data, "token")
 }
 
 resource "github_actions_secret" "cluster-name" {
   for_each        = toset(var.github_repositories)
   repository      = each.key
-  secret_name     = var.github_actions_secret_kube_cluster
+  secret_name     = var.env_prefix != "" ? "${var.env_prefix}_${var.github_actions_secret_kube_cluster}" : var.github_actions_secret_kube_cluster
   plaintext_value = var.kubernetes_cluster
 }
 
 resource "github_actions_secret" "cluster-namespace" {
   for_each        = toset(var.github_repositories)
   repository      = each.key
-  secret_name     = var.github_actions_secret_kube_namespace
+  secret_name     = var.env_prefix != "" ? "${var.env_prefix}_${var.github_actions_secret_kube_namespace}" : var.github_actions_secret_kube_namespace
   plaintext_value = var.namespace
 }
 
@@ -103,7 +103,7 @@ resource "github_actions_environment_secret" "serviceaccount-cert" {
   }
   repository      = each.value.repository
   environment     = each.value.environment
-  secret_name     = var.github_actions_secret_kube_cert
+  secret_name     = var.env_prefix != "" ? "${var.env_prefix}_${var.github_actions_secret_kube_cert}" : var.github_actions_secret_kube_cert
   plaintext_value = lookup(data.kubernetes_secret.github_actions_secret.data, "ca.crt")
 }
 
@@ -113,7 +113,7 @@ resource "github_actions_environment_secret" "serviceaccount-token" {
   }
   repository      = each.value.repository
   environment     = each.value.environment
-  secret_name     = var.github_actions_secret_kube_token
+  secret_name     = var.env_prefix != "" ? "${var.env_prefix}_${var.github_actions_secret_kube_token}" : var.github_actions_secret_kube_token
   plaintext_value = lookup(data.kubernetes_secret.github_actions_secret.data, "token")
 }
 
@@ -123,7 +123,7 @@ resource "github_actions_environment_secret" "cluster-name" {
   }
   repository      = each.value.repository
   environment     = each.value.environment
-  secret_name     = var.github_actions_secret_kube_cluster
+  secret_name     = var.env_prefix != "" ?  "${var.env_prefix}_${var.github_actions_secret_kube_cluster}" : var.github_actions_secret_kube_cluster
   plaintext_value = var.kubernetes_cluster
 }
 
@@ -133,6 +133,6 @@ resource "github_actions_environment_secret" "cluster-namespace" {
   }
   repository      = each.value.repository
   environment     = each.value.environment
-  secret_name     = var.github_actions_secret_kube_namespace
+  secret_name     = var.env_prefix != "" ? "${var.env_prefix}_${var.github_actions_secret_kube_namespace}" : var.github_actions_secret_kube_namespace
   plaintext_value = var.namespace
 }

--- a/template/serviceaccount.tmpl
+++ b/template/serviceaccount.tmpl
@@ -1,5 +1,5 @@
 module "serviceaccount" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.7.6"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount?ref=0.7.7"
 
   namespace = var.namespace
   kubernetes_cluster = var.kubernetes_cluster

--- a/variables.tf
+++ b/variables.tf
@@ -132,3 +132,9 @@ variable "github_actions_secret_kube_token" {
   default     = "KUBE_TOKEN"
   type        = string
 }
+
+variable "env_prefix" {
+  description = "the prefix for github actions secret name eg. DEV or PROD"
+  default     = ""
+  type        = string
+}


### PR DESCRIPTION
* add `env_prefix` variable to the module

The purpose of this variable is to enable a github repo to store multiple sets of secrets, which is useful if a repo needs to deploy to multiple clusters.

eg. DEV_KUBE_CERT and PROD_KUBE_CERT

currently the following is created:

![Screenshot 2023-02-13 at 12 15 09](https://user-images.githubusercontent.com/29051079/218455182-d7b103aa-3958-4b9e-bf0d-b10cfa43b6f5.png)
