### PR TITLE
feat: 🎸 create the SA secret, default behaviour changed in 1.24

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Local .terraform directories
 **/.terraform/*
 
+.terraform.lock.hcl
+
 # .tfstate files
 *.tfstate
 *.tfstate.*

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ No modules.
 | [github_actions_secret.serviceaccount-token](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_secret) | resource |
 | [kubernetes_role.github_actions_role](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/role) | resource |
 | [kubernetes_role_binding.github-actions-rolebinding](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/role_binding) | resource |
+| [kubernetes_secret_v1.serviceaccount-token](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1) | resource |
 | [kubernetes_service_account.github_actions_serviceaccount](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service_account) | resource |
-| [kubernetes_secret.github_actions_secret](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/data-sources/secret) | data source |
 
 ## Inputs
 


### PR DESCRIPTION
https://registry.terraform.io/providers/hashicorp/kubernetes/2.22.0/docs/resources/secret_v1

This change explicitly adds a secret resource which was previously created by default for service accounts but now we have upgraded to k8s 1.24 service accounts do not create this secret by default

The old secret and token are still valid but the SA will only indicate it has one secret, the newly created token