### PR TITLE
remove serviceaccount ref to token secret

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -25,10 +25,6 @@ resource "kubernetes_service_account" "github_actions_serviceaccount" {
     name      = var.serviceaccount_name
     namespace = var.namespace
   }
-
-  secret {
-    name = "${var.serviceaccount_name}-token-${var.serviceaccount_token_rotated_date}"
-  }
 }
 
 resource "kubernetes_secret_v1" "serviceaccount-token" {


### PR DESCRIPTION
this is to avoid kubernetes flagging our manually created SA tokens as a auto-generated one. ref:https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#auto-generated-legacy-serviceaccount-token-clean-up

The secret is still marked as legacy and a label is added as of 1.27 kubernetes version. In the future versions, these secrets are validated for usage based on last used, if auto-generated etc.
```
  labels:
    kubernetes.io/legacy-token-last-used: "2024-04-02"
```
